### PR TITLE
Improve offline whisper handling

### DIFF
--- a/lib/whisper.ts
+++ b/lib/whisper.ts
@@ -1,16 +1,22 @@
 let whisperModel: any = null
+let currentModelSize: 'base' | 'small' | null = null
 
-export async function loadWhisperModel() {
-  if (!whisperModel) {
+export async function loadWhisperModel(size: 'base' | 'small' = 'base') {
+  if (!whisperModel || currentModelSize !== size) {
     const { pipeline } = await import('@xenova/transformers');
-    whisperModel = await pipeline('automatic-speech-recognition', 'Xenova/whisper-base', { quantized: true });
+    const modelId = size === 'small' ? 'Xenova/whisper-small' : 'Xenova/whisper-base';
+    whisperModel = await pipeline('automatic-speech-recognition', modelId, { quantized: true });
+    currentModelSize = size;
   }
   return whisperModel;
 }
 
-export async function transcribeBlob(blob: Blob): Promise<string> {
-  const model = await loadWhisperModel();
-  const buffer = await blob.arrayBuffer();
-  const result = await model(buffer);
+export async function transcribeBlob(blob: Blob, size: 'base' | 'small' = 'base'): Promise<string> {
+  const model = await loadWhisperModel(size);
+  const audioCtx = new AudioContext({ sampleRate: 16000 });
+  const arrayBuffer = await blob.arrayBuffer();
+  const decoded = await audioCtx.decodeAudioData(arrayBuffer);
+  const float32 = decoded.getChannelData(0);
+  const result = await model(float32);
   return result.text as string;
 }


### PR DESCRIPTION
## Summary
- add model size selection (small or base)
- reload Whisper model when selection changes
- show selected model in loading screen
- pass selected model size when recording

## Testing
- `npx tsc --noEmit` *(fails to resolve modules)*
- `npm install` *(fails: dependency conflict)*


------
https://chatgpt.com/codex/tasks/task_e_683f4a47142c832a9a11e8b55381cb2b